### PR TITLE
Fix recordingStarted to fire when "record again" button is pressed.

### DIFF
--- a/src/components/App/ExpressRecorder.tsx
+++ b/src/components/App/ExpressRecorder.tsx
@@ -387,6 +387,7 @@ export class ExpressRecorder extends Component<ExpressRecorderProps, State> {
             doCountdown: true,
             doPlayback: false
         });
+        this.dispatcher.dispatchEvent(RecorderEvents.recordingStarted);
     };
     handleCountdownComplete = () => {
         if (this.state.doCountdown) {


### PR DESCRIPTION
### PR Info
- [x] Please functional test this PR
- [ ] Already tested in KMS and stand alone

#### Main changes
Fixess when the "record again" button is pressed, the recordingStarted event is not fired.
#### Known effected areas
#### Special considerations


